### PR TITLE
Added ability to collapse all items on trigger

### DIFF
--- a/js/ang-accordion.js
+++ b/js/ang-accordion.js
@@ -11,7 +11,16 @@
       .module('angAccordion', ['collapsibleItem'])
       .controller('angAccordionController', ['$scope', function($scope){
         var collapsibleItems = [];
-          
+
+        $scope.$watch('collapseAll', function () {
+          if ($scope.collapseAll == true) {
+              angular.forEach(collapsibleItems, function (collapsibleItem) {
+                collapsibleItem.isOpenned = false;
+                collapsibleItem.icon = collapsibleItem.closeIcon;
+              });
+          };
+        });
+
           this.openCollapsibleItem = function(collapsibleItemToOpen) {
             if( $scope.oneAtATime ) {
               angular.forEach(collapsibleItems, function(collapsibleItem) {
@@ -24,7 +33,7 @@
 
           this.addCollapsibleItem = function(collapsibleItem) {
             collapsibleItems.push(collapsibleItem);
-            
+
             if ( $scope.closeIconClass !== undefined || $scope.openIconClass !== undefined ) {
               collapsibleItem.iconsType = 'class';
               collapsibleItem.closeIcon = $scope.closeIconClass;
@@ -51,7 +60,8 @@
           openIconUrl: '@',
           closeIconClass: '@',
           openIconClass: '@',
-          iconPosition: '@' 
+          iconPosition: '@',
+          collapseAll: '='
         },
         controller: 'angAccordionController',
         template: '<div class="accordion" ng-transclude></div>'
@@ -72,7 +82,7 @@
         link: function(scope, element, attrs, accordionController) {
           scope.isOpenned = (scope.initiallyOpen) ? true : false;
           accordionController.addCollapsibleItem(scope);
-          
+
           if(scope.isOpenned)
             scope.icon = scope.openIcon;
           else
@@ -81,7 +91,7 @@
           scope.toggleCollapsibleItem = function () {
             if(scope.itemDisabled)
               return;
-            
+
             if(!scope.isOpenned) {
               accordionController.openCollapsibleItem(this);
               scope.icon = scope.openIcon;


### PR DESCRIPTION
Since we are using the accordion with md-sidenav, we need to collapse the opened accordion items when the sidenav closes. This feature could be extended to collapsing the items on any event such as a button click. 