### PR TITLE
fix collapse opening all when it's not wanted

### DIFF
--- a/js/ang-accordion.js
+++ b/js/ang-accordion.js
@@ -15,7 +15,7 @@
               });
           }
           // dynamically expand all panels
-          else { // expand all
+          else if( $scope.collapseAll === false) { // expand all is set to false
               angular.forEach(collapsibleItems, function (collapsibleItem) {
                   collapsibleItem.isOpenned = true;
                   collapsibleItem.icon = collapsibleItem.openIcon;


### PR DESCRIPTION
If collapseAll property is not set, all accordions are open by default. Which is not the desired result. Only expand all accordions if collapseAll is set to false